### PR TITLE
Check against rc channel

### DIFF
--- a/devtools/osx-build.sh
+++ b/devtools/osx-build.sh
@@ -1,4 +1,4 @@
-# upgrade Bash to version 4, for associative array support
+chec# upgrade Bash to version 4, for associative array support
 if [[ ${BASH_VERSINFO[0]} < 4 ]]; then
     brew install bash wget
     /usr/local/bin/bash -uxe $0
@@ -108,5 +108,5 @@ conda config --add channels omnia/label/betacuda${CUDA_SHORT_VERSION};
 
 #for PY_BUILD_VERSION in "27" "35" "36" "37"; do
 for PY_BUILD_VERSION in "37" "36" "35" "27"; do
-    ./conda-build-all -vvv --python $PY_BUILD_VERSION --check-against omnia/label/beta --check-against omnia/label/betacuda${CUDA_SHORT_VERSION} --check-against omnia/label/dev --check-against omnia/label/devcuda${CUDA_SHORT_VERSION} --numpy "1.15" $UPLOAD -- *
+    ./conda-build-all -vvv --python $PY_BUILD_VERSION --check-against omnia/label/beta --check-against omnia/label/betacuda${CUDA_SHORT_VERSION} --check-against omnia/label/rc --check-against omnia/label/rccuda${CUDA_SHORT_VERSION} --numpy "1.15" $UPLOAD -- *
 done


### PR DESCRIPTION
This PR updates the builds to instead check against the `rc` channels to ensure that retriggering travis will only build packages that don't already exist on anaconda cloud.